### PR TITLE
Keep the `keep_releases` number of releases on rollback

### DIFF
--- a/mrblib/resource_executor/deploy_directory.rb
+++ b/mrblib/resource_executor/deploy_directory.rb
@@ -76,7 +76,8 @@ module ::MItamae
           @release_path = target_release_path
 
           rp_index = all_releases.index(release_path)
-          releases_to_nuke = all_releases[(rp_index + 1)..-1]
+          chop = -1 - desired.keep_releases # always keep the `keep_releases` number of releases
+          releases_to_nuke = all_releases[(rp_index + 1)..chop]
 
           rollback
 


### PR DESCRIPTION
This lets `rollback_to` also respect `keep_releases` like `cleanup!` https://github.com/itamae-plugins/mitamae-plugin-resource-deploy_directory/blob/5ab71276f145b96e8f9b0f54da16f2af6cafa5a5/mrblib/resource_executor/deploy_directory.rb#L172-L173 This behavior didn't exist in Chef, but this seems useful for our graceful restart.

Please have a look @muga